### PR TITLE
Fix layotto import path

### DIFF
--- a/static/layotto
+++ b/static/layotto
@@ -1,5 +1,14 @@
 <html>
   <head>
-    <meta name="go-import" content="mosn.io/layotto git https://github.com/layotto/layotto">
+    <meta name="go-import" content="mosn.io/layotto git https://github.com/mosn/layotto">
+    <meta name="go-source" content="mosn.io/layotto     https://github.com/mosn/layotto https://github.com/mosn/layotto/tree/main{/dir} https://github.com/mosn/layotto/blob/main{/dir}/{file}#L{line}">
+    <meta name="go-import" content="mosn.io/layotto/components git https://github.com/mosn/layotto/tree/main/components">
+    <meta name="go-source" content="mosn.io/layotto/components     https://github.com/mosn/layotto/tree/main/components https://github.com/mosn/layotto/tree/main/components{/dir} https://github.com/mosn/layotto/blob/main/components{/dir}/{file}#L{line}">
+    <meta name="go-import" content="mosn.io/layotto/spec git https://github.com/mosn/layotto/tree/main/spec">
+    <meta name="go-source" content="mosn.io/layotto/spec     https://github.com/mosn/layotto/tree/main/spec https://github.com/mosn/layotto/tree/main/spec{/dir} https://github.com/mosn/layotto/blob/main/spec{/dir}/{file}#L{line}">
+    <meta name="go-import" content="mosn.io/layotto/sdk/go-sdk git https://github.com/mosn/layotto/tree/main/sdk/go-sdk">
+    <meta name="go-source" content="mosn.io/layotto/sdk/go-sdk     https://github.com/mosn/layotto/tree/main/sdk/go-sdk https://github.com/mosn/layotto/tree/main/sdk/go-sdk{/dir} https://github.com/mosn/layotto/blob/main/sdk/go-sdk{/dir}/{file}#L{line}">
+    <meta name="go-import" content="mosn.io/layotto/demo git https://github.com/mosn/layotto/tree/main/demo">
+    <meta name="go-source" content="mosn.io/layotto/demo     https://github.com/mosn/layotto/tree/main/demo https://github.com/mosn/layotto/tree/main/demo{/dir} https://github.com/mosn/layotto/blob/main/demo{/dir}/{file}#L{line}">
   </head>
 </html>


### PR DESCRIPTION
Fix #141 

Add `mosn.io/layotto/components`, `mosn.io/layotto/spec`, `mosn.io/layotto/sdk/go-sdk`, `mosn.io/layotto/demo` to import page.